### PR TITLE
Harden LSP document handling

### DIFF
--- a/sqleibniz/src/lsp/handlers/diagnostic.rs
+++ b/sqleibniz/src/lsp/handlers/diagnostic.rs
@@ -40,12 +40,12 @@ pub fn handle(
     id: RequestId,
     _: DocumentDiagnosticParams,
 ) -> Result<(), LspError> {
-    eprintln!("got diagnostic request #{id}");
     let diagnostics = lsp_types::FullDocumentDiagnosticReport {
         result_id: None,
         items: errors.into_iter().map(Error::into).collect(),
     };
-    let result = serde_json::to_value(&diagnostics).unwrap();
+    let result = serde_json::to_value(&diagnostics)
+        .map_err(|err| format!("failed to serialize diagnostics: {err}"))?;
     let resp = Response {
         id,
         result: Some(result),

--- a/sqleibniz/src/lsp/handlers/diagnostic.rs
+++ b/sqleibniz/src/lsp/handlers/diagnostic.rs
@@ -3,19 +3,23 @@ use lsp_types::{Diagnostic, DiagnosticSeverity, DocumentDiagnosticParams, Positi
 
 use crate::{error::Error, lsp::error::LspError};
 
+fn error_range(error: &Error) -> Range {
+    Range::new(
+        Position {
+            line: error.line as u32,
+            character: error.start as u32,
+        },
+        Position {
+            line: error.line as u32,
+            character: usize::max(error.end, error.start + 1) as u32,
+        },
+    )
+}
+
 impl From<Error> for Diagnostic {
     fn from(value: Error) -> Self {
         Self {
-            range: Range::new(
-                Position {
-                    line: value.line as u32,
-                    character: value.start as u32,
-                },
-                Position {
-                    line: value.line as u32,
-                    character: value.end as u32,
-                },
-            ),
+            range: error_range(&value),
             severity: Some(DiagnosticSeverity::ERROR),
             code: Some(lsp_types::NumberOrString::String(
                 value.rule.name().to_string(),
@@ -52,4 +56,41 @@ pub fn handle(
         .send(Message::Response(resp))
         .map_err(|_| "failed to send diagnostics")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{error::Error, lsp::handlers::diagnostic::error_range, types::rules::Rule};
+
+    fn error(start: usize, end: usize) -> Error {
+        Error {
+            file: "test.sql".into(),
+            line: 2,
+            rule: Rule::Syntax,
+            note: "note".into(),
+            msg: "msg".into(),
+            start,
+            end,
+            improved_line: None,
+            doc_url: None,
+        }
+    }
+
+    #[test]
+    fn range_preserves_zero_based_positions() {
+        let range = error_range(&error(3, 8));
+
+        assert_eq!(range.start.line, 2);
+        assert_eq!(range.start.character, 3);
+        assert_eq!(range.end.line, 2);
+        assert_eq!(range.end.character, 8);
+    }
+
+    #[test]
+    fn range_is_never_empty() {
+        let range = error_range(&error(3, 3));
+
+        assert_eq!(range.start.character, 3);
+        assert_eq!(range.end.character, 4);
+    }
 }

--- a/sqleibniz/src/lsp/handlers/hover.rs
+++ b/sqleibniz/src/lsp/handlers/hover.rs
@@ -9,7 +9,6 @@ pub fn handle(
     id: RequestId,
     params: HoverParams,
 ) -> Result<(), LspError> {
-    eprintln!("got hover request #{id}");
     let Position { line, character } = params.text_document_position_params.position;
     let text = match ast
         .unwrap_or_default()
@@ -32,7 +31,8 @@ pub fn handle(
         }),
         range: None,
     };
-    let result = serde_json::to_value(&hover_result).unwrap();
+    let result = serde_json::to_value(&hover_result)
+        .map_err(|err| format!("failed to serialize hover: {err}"))?;
     let resp = Response {
         id,
         result: Some(result),

--- a/sqleibniz/src/lsp/handlers/hover.rs
+++ b/sqleibniz/src/lsp/handlers/hover.rs
@@ -5,13 +5,14 @@ use crate::{lsp::error::LspError, parser::nodes::Node};
 
 pub fn handle(
     connection: &Connection,
-    ast: &[Box<dyn Node>],
+    ast: Option<&[Box<dyn Node>]>,
     id: RequestId,
     params: HoverParams,
 ) -> Result<(), LspError> {
     eprintln!("got hover request #{id}");
     let Position { line, character } = params.text_document_position_params.position;
     let text = match ast
+        .unwrap_or_default()
         .iter()
         .filter(|n| {
             let tok = n.token();

--- a/sqleibniz/src/lsp/mod.rs
+++ b/sqleibniz/src/lsp/mod.rs
@@ -1,6 +1,8 @@
 mod error;
 mod handlers;
 
+use std::collections::HashMap;
+
 use error::LspError;
 use lsp_server::{Connection, ExtractError, Message, Notification, Request, RequestId};
 use lsp_types::{
@@ -71,11 +73,28 @@ pub fn start() -> Result<(), LspError> {
     Ok(())
 }
 
+#[derive(Default)]
+struct DocumentState {
+    ast: Vec<Box<dyn Node>>,
+    errors: Vec<super::error::Error>,
+}
+
+fn analyze_document(text: &[u8], name: &str) -> DocumentState {
+    let text = text.to_vec();
+    let mut l = Lexer::new(&text, name);
+    let tokens = l.run();
+    let mut errors = l.errors;
+    let mut p = Parser::new(tokens, name);
+    let ast = p.parse();
+    errors.append(&mut p.errors);
+
+    DocumentState { ast, errors }
+}
+
 fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), LspError> {
     let _params: InitializeParams = serde_json::from_value(params).unwrap();
     lsp_log!("starting event loop");
-    let mut ast: Vec<Box<dyn Node>> = vec![];
-    let mut errors: Vec<super::error::Error> = vec![];
+    let mut documents = HashMap::<String, DocumentState>::new();
     for msg in &connection.receiver {
         eprintln!("got msg: {msg:?}");
         match msg {
@@ -88,9 +107,19 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                     "textDocument/hover" => {
                         match cast::<HoverRequest>(req) {
                             Ok((id, params)) => {
-                                if let Err(e) =
-                                    handlers::hover::handle(&connection, &ast, id, params)
-                                {
+                                let state = documents.get(
+                                    &params
+                                        .text_document_position_params
+                                        .text_document
+                                        .uri
+                                        .to_string(),
+                                );
+                                if let Err(e) = handlers::hover::handle(
+                                    &connection,
+                                    state.map(|s| s.ast.as_slice()),
+                                    id,
+                                    params,
+                                ) {
                                     eprintln!("[sqleibniz]: err: {}", e);
                                 }
                                 continue;
@@ -101,9 +130,10 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                     "textDocument/diagnostic" => {
                         match cast::<DocumentDiagnosticRequest>(req) {
                             Ok((id, params)) => {
+                                let state = documents.get(&params.text_document.uri.to_string());
                                 if let Err(e) = handlers::diagnostic::handle(
                                     &connection,
-                                    errors.clone(),
+                                    state.map(|s| s.errors.clone()).unwrap_or_default(),
                                     id,
                                     params,
                                 ) {
@@ -125,15 +155,14 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                 "textDocument/didChange" => {
                     match cast_noti::<DidChangeTextDocument>(not) {
                         Ok(params) => {
-                            let text = &(params.content_changes[0].text.clone().into_bytes());
-                            let formatted_path =
-                                params.text_document.uri.to_string().replace("file://", "");
-                            let mut l = Lexer::new(text, &formatted_path);
-                            let tokens = l.run();
-                            errors = l.errors;
-                            let mut p = Parser::new(tokens, &formatted_path);
-                            ast = p.parse();
-                            errors.append(&mut p.errors);
+                            if let Some(change) = params.content_changes.first() {
+                                let uri = params.text_document.uri.to_string();
+                                let formatted_path = uri.replace("file://", "");
+                                documents.insert(
+                                    uri,
+                                    analyze_document(change.text.as_bytes(), &formatted_path),
+                                );
+                            }
                         }
                         Err(err) => panic!("failed to cast notification: {err:?}"),
                     };
@@ -141,15 +170,15 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                 "textDocument/didOpen" => {
                     match cast_noti::<DidOpenTextDocument>(not) {
                         Ok(params) => {
-                            let text = &(params.text_document.text.into_bytes());
-                            let formatted_path =
-                                params.text_document.uri.to_string().replace("file://", "");
-                            let mut l = Lexer::new(text, &formatted_path);
-                            let tokens = l.run();
-                            errors = l.errors;
-                            let mut p = Parser::new(tokens, &formatted_path);
-                            ast = p.parse();
-                            errors.append(&mut p.errors);
+                            let uri = params.text_document.uri.to_string();
+                            let formatted_path = uri.replace("file://", "");
+                            documents.insert(
+                                uri,
+                                analyze_document(
+                                    params.text_document.text.as_bytes(),
+                                    &formatted_path,
+                                ),
+                            );
                         }
                         Err(err) => panic!("failed to cast notification: {err:?}"),
                     };

--- a/sqleibniz/src/lsp/mod.rs
+++ b/sqleibniz/src/lsp/mod.rs
@@ -4,7 +4,10 @@ mod handlers;
 use std::collections::HashMap;
 
 use error::LspError;
-use lsp_server::{Connection, ExtractError, Message, Notification, Request, RequestId};
+use lsp_server::{
+    Connection, ErrorCode, ExtractError, Message, Notification, Request, RequestId, Response,
+    ResponseError,
+};
 use lsp_types::{
     DiagnosticOptions, InitializeParams, SaveOptions, ServerCapabilities, TextDocumentSyncKind,
     TextDocumentSyncOptions,
@@ -92,19 +95,19 @@ fn analyze_document(text: &[u8], name: &str) -> DocumentState {
 }
 
 fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), LspError> {
-    let _params: InitializeParams = serde_json::from_value(params).unwrap();
+    let _params: InitializeParams = serde_json::from_value(params)
+        .map_err(|err| format!("failed to parse initialize params: {err}"))?;
     lsp_log!("starting event loop");
     let mut documents = HashMap::<String, DocumentState>::new();
     for msg in &connection.receiver {
-        eprintln!("got msg: {msg:?}");
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req)? {
                     return Ok(());
                 }
-                eprintln!("got request: {req:?}");
                 match req.method.as_str() {
                     "textDocument/hover" => {
+                        let id = req.id.clone();
                         match cast::<HoverRequest>(req) {
                             Ok((id, params)) => {
                                 let state = documents.get(
@@ -124,10 +127,11 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 }
                                 continue;
                             }
-                            Err(err) => panic!("{err:?}"),
+                            Err(err) => send_request_error(&connection, id, err)?,
                         };
                     }
                     "textDocument/diagnostic" => {
+                        let id = req.id.clone();
                         match cast::<DocumentDiagnosticRequest>(req) {
                             Ok((id, params)) => {
                                 let state = documents.get(&params.text_document.uri.to_string());
@@ -141,16 +145,18 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 }
                                 continue;
                             }
-                            Err(err) => panic!("{err:?}"),
+                            Err(err) => send_request_error(&connection, id, err)?,
                         };
                     }
-                    _ => lsp_log!("unsupported method"),
+                    _ => send_error(
+                        &connection,
+                        req.id,
+                        ErrorCode::MethodNotFound,
+                        format!("unsupported method '{}'", req.method),
+                    )?,
                 }
-                // ...
             }
-            Message::Response(resp) => {
-                eprintln!("got response: {resp:?}");
-            }
+            Message::Response(_) => {}
             Message::Notification(not) => match not.method.as_str() {
                 "textDocument/didChange" => {
                     match cast_noti::<DidChangeTextDocument>(not) {
@@ -164,7 +170,7 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 );
                             }
                         }
-                        Err(err) => panic!("failed to cast notification: {err:?}"),
+                        Err(err) => eprintln!("[sqleibniz]: failed to parse notification: {err}"),
                     };
                 }
                 "textDocument/didOpen" => {
@@ -180,13 +186,43 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 ),
                             );
                         }
-                        Err(err) => panic!("failed to cast notification: {err:?}"),
+                        Err(err) => eprintln!("[sqleibniz]: failed to parse notification: {err}"),
                     };
                 }
                 _ => lsp_log!("unsupported method"),
             },
         }
     }
+    Ok(())
+}
+
+fn send_request_error(
+    connection: &Connection,
+    id: RequestId,
+    err: ExtractError<Request>,
+) -> Result<(), LspError> {
+    send_error(connection, id, ErrorCode::InvalidParams, err.to_string())
+}
+
+fn send_error(
+    connection: &Connection,
+    id: RequestId,
+    code: ErrorCode,
+    message: String,
+) -> Result<(), LspError> {
+    let resp = Response {
+        id,
+        result: None,
+        error: Some(ResponseError {
+            code: code as i32,
+            message,
+            data: None,
+        }),
+    };
+    connection
+        .sender
+        .send(Message::Response(resp))
+        .map_err(|_| "failed to send error response")?;
     Ok(())
 }
 


### PR DESCRIPTION

- keep LSP analysis state per document URI for hover and diagnostics
- emit non-empty diagnostic ranges while preserving zero-based coordinates
- handle malformed LSP messages with JSON-RPC errors instead of panics, and reduce debug stderr noise