### PR TITLE
Execute Lua hooks in CLI analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dynamic correctness. See below for a list of currently implemented features.
 - [ ] lua scripting
   - [x] configure sqleibniz with lua
   - [x] scripting to hook into node analysis for custom diagnostics
-  - [ ] execute hooks when encountering the defined node while analysing
+  - [x] execute hooks when encountering the defined node while analysing
 
 ### Supported Sql statements
 
@@ -140,6 +140,7 @@ Options:
           - unimplemented:             Source file contains constructs sqleibniz does not yet understand
           - unknown-keyword:           Source file contains an unknown keyword
           - bad-sqleibniz-instruction: Source file contains invalid sqleibniz instruction
+          - hook:                      User-defined Lua hook reported a diagnostic
           - sqlite-unsupported:        Source file uses sql features sqlite does not support
           - quirk:                     Sqlite or SQL quirk: https://www.sqlite.org/quirks.html; anything where SQLite deviates from a stricter, conventional SQL model
           - unterminated-string:       Source file contains an unterminated string
@@ -186,6 +187,7 @@ leibniz = {
         "NoStatements",            -- source file contains no statements
         "Unimplemented",           -- construct is not implemented yet
         "BadSqleibnizInstruction", -- source file contains a bad sqleibniz instruction
+        "Hook",                    -- a user-defined Lua hook reported a diagnostic
 
         -- ignore sqlite specific diagnostics:
 
@@ -205,7 +207,7 @@ leibniz = {
             -- summarises the hooks content
             name = "idents should be lowercase",
             -- instructs sqleibniz which node to execute the `hook` for
-            node = "literal",
+            node = "Token",
             -- sqleibniz calls the hook function once it encounters a node name
             -- matching the hook.node content
             --
@@ -213,14 +215,19 @@ leibniz = {
             --
             --```
             --    node: {
+            --     node: string,
             --     kind: string,
             --     content: string,
+            --     text: string,
+            --     line: number,
+            --     start: number,
+            --     finish: number,
             --     children: node[],
             --    }
             --```
             --
             hook = function(node)
-                if node.kind == "ident" then
+                if node.kind == "Ident" then
                     if string.match(node.content, "%u") then
                         -- returing an error passes the diagnostic to sqleibniz,
                         -- thus a pretty message with the name of the hook, the
@@ -233,10 +240,10 @@ leibniz = {
         },
         {
             name = "idents shouldn't be longer than 12 characters",
-            node = "literal",
+            node = "Token",
             hook = function(node)
                 local max_size = 12
-                if node.kind == "ident" then
+                if node.kind == "Ident" then
                     if string.len(node.content) >= max_size then
                         error("idents shouldn't be longer than " .. max_size .. " characters")
                     end
@@ -283,6 +290,7 @@ warn: Ignoring the following diagnostics, as specified:
  -> NoStatements
  -> Unimplemented
  -> BadSqleibnizInstruction
+ -> Hook
 ======================== example/sqleibniz.sql =========================
 error[Syntax]: Unexpected Literal
  -> /home/teo/programming/sqleibniz/example/sqleibniz.sql:13:20

--- a/leibniz.lua
+++ b/leibniz.lua
@@ -8,7 +8,7 @@ leibniz = {
         "NoStatements",            -- source file contains no statements
         "Unimplemented",           -- construct is not implemented yet
         "BadSqleibnizInstruction", -- source file contains a bad sqleibniz instruction
-        -- "Hook", -- a user-defined Lua hook reported a diagnostic
+        "Hook",                    -- a user-defined Lua hook reported a diagnostic
 
         -- ignore sqlite specific diagnostics:
 
@@ -28,7 +28,7 @@ leibniz = {
             -- summarises the hooks content
             name = "idents should be lowercase",
             -- instructs sqleibniz which node to execute the `hook` for
-            node = "literal",
+            node = "Token",
             -- sqleibniz calls the hook function once it encounters a node name
             -- matching the hook.node content
             --
@@ -36,14 +36,19 @@ leibniz = {
             --
             --```
             --    node: {
+            --     node: string,
             --     kind: string,
             --     content: string,
+            --     text: string,
+            --     line: number,
+            --     start: number,
+            --     finish: number,
             --     children: node[],
             --    }
             --```
             --
             hook = function(node)
-                if node.kind == "ident" then
+                if node.kind == "Ident" then
                     if string.match(node.content, "%u") then
                         -- returing an error passes the diagnostic to sqleibniz,
                         -- thus a pretty message with the name of the hook, the
@@ -56,20 +61,14 @@ leibniz = {
         },
         {
             name = "idents shouldn't be longer than 12 characters",
-            node = "literal",
+            node = "Token",
             hook = function(node)
                 local max_size = 12
-                if node.kind == "ident" then
+                if node.kind == "Ident" then
                     if string.len(node.content) >= max_size then
                         error("idents shouldn't be longer than " .. max_size .. " characters")
                     end
                 end
-            end
-        },
-        {
-            name = "hook test",
-            hook = function(node)
-                print(node.kind .. " " .. node.text .. " " .. #node.children)
             end
         }
     }

--- a/leibniz.lua
+++ b/leibniz.lua
@@ -8,6 +8,7 @@ leibniz = {
         "NoStatements",            -- source file contains no statements
         "Unimplemented",           -- construct is not implemented yet
         "BadSqleibnizInstruction", -- source file contains a bad sqleibniz instruction
+        -- "Hook", -- a user-defined Lua hook reported a diagnostic
 
         -- ignore sqlite specific diagnostics:
 

--- a/sqleibniz/src/main.rs
+++ b/sqleibniz/src/main.rs
@@ -9,7 +9,10 @@ use sqleibniz::error::{self, Error, print_str_colored, warn};
 use sqleibniz::highlight::builder;
 use sqleibniz::lexer::Lexer;
 use sqleibniz::parser;
-use sqleibniz::types::config::Config;
+use sqleibniz::parser::nodes::Node;
+use sqleibniz::types::Token;
+use sqleibniz::types::config::{Config, Hook};
+use sqleibniz::types::ctx::HookContext;
 use sqleibniz::types::rules::Rule;
 
 /// LSP and analysis cli for sql. Check for valid syntax, semantics and perform dynamic analysis.
@@ -92,6 +95,62 @@ struct FileResult {
     diagnostics: Vec<Error>,
 }
 
+fn hook_error_note(err: mlua::Error) -> String {
+    match err {
+        mlua::Error::RuntimeError(msg) => msg,
+        mlua::Error::CallbackError { cause, .. } => cause.to_string(),
+        err => err.to_string(),
+    }
+}
+
+fn hook_error(file: &str, hook: &Hook, ctx: &HookContext, err: mlua::Error) -> Error {
+    Error {
+        file: file.into(),
+        line: ctx.line,
+        rule: Rule::Hook,
+        note: hook_error_note(err),
+        msg: hook.name.clone(),
+        start: ctx.start,
+        end: ctx.finish,
+        improved_line: None,
+        doc_url: None,
+    }
+}
+
+fn hook_matches(hook: &Hook, ctx: &HookContext) -> bool {
+    hook.node
+        .as_deref()
+        .is_none_or(|node| node == ctx.node.as_str())
+}
+
+fn run_hook_context(file: &str, hooks: &[Hook], ctx: &HookContext, errors: &mut Vec<Error>) {
+    for hook in hooks {
+        if hook_matches(hook, ctx) {
+            if let Err(err) = hook.exec(ctx.clone()) {
+                errors.push(hook_error(file, hook, ctx, err));
+            }
+        }
+    }
+
+    for child in &ctx.children {
+        run_hook_context(file, hooks, child, errors);
+    }
+}
+
+fn run_hooks(file: &str, hooks: &[Hook], ast: &[Box<dyn Node>], tokens: &[Token]) -> Vec<Error> {
+    let mut errors = vec![];
+
+    for node in ast {
+        run_hook_context(file, hooks, &node.as_hook_context(), &mut errors);
+    }
+
+    for token in tokens {
+        run_hook_context(file, hooks, &HookContext::token(token), &mut errors);
+    }
+
+    errors
+}
+
 fn main() {
     let args = Cli::parse();
 
@@ -123,11 +182,9 @@ fn main() {
         disabled_rules: vec![],
         hooks: None,
     };
+    let lua = mlua::Lua::new();
 
     if !args.ignore_config {
-        // lua defined here because it would be dropped at the end of configuration(), in the
-        // future this will probably need to be moved one scope up to life long enough for analysis
-        let lua = mlua::Lua::new();
         match configuration(&lua, &args.config) {
             Ok(conf) => config = conf,
             Err(err) => {
@@ -224,6 +281,10 @@ fn main() {
             }
 
             errors.append(&mut parser.errors);
+
+            if let Some(hooks) = config.hooks.as_deref() {
+                errors.append(&mut run_hooks(&file.name, hooks, &ast, &toks));
+            }
         }
 
         let mut processed_errors = errors

--- a/sqleibniz/src/parser/debug.rs
+++ b/sqleibniz/src/parser/debug.rs
@@ -1,6 +1,6 @@
 use crate::{
     parser::nodes::*,
-    types::{Keyword, Token, Type, storage::SqliteStorageClass},
+    types::{Keyword, Token, Type, ctx::HookContext, storage::SqliteStorageClass},
 };
 
 /// impl FieldSerializable for $tt via serde_json::to_value(self).unwrap()
@@ -18,6 +18,22 @@ macro_rules! impl_field_serializable_with_serde_to_value {
 
 pub trait FieldSerializable {
     fn field_as_serializable(&self) -> serde_json::Value;
+}
+
+pub trait FieldHookContexts {
+    fn field_hook_contexts(&self) -> Vec<HookContext>;
+}
+
+macro_rules! impl_empty_field_hook_contexts {
+    ($($tt:ty),*) => {
+        $(
+            impl FieldHookContexts for $tt {
+                fn field_hook_contexts(&self) -> Vec<HookContext> {
+                    vec![]
+                }
+            }
+        )*
+    };
 }
 
 impl_field_serializable_with_serde_to_value!(
@@ -107,9 +123,21 @@ impl FieldSerializable for Token {
     }
 }
 
+impl FieldHookContexts for Token {
+    fn field_hook_contexts(&self) -> Vec<HookContext> {
+        vec![HookContext::token(self)]
+    }
+}
+
 impl FieldSerializable for Box<dyn Node> {
     fn field_as_serializable(&self) -> serde_json::Value {
         self.as_serializable()
+    }
+}
+
+impl FieldHookContexts for Box<dyn Node> {
+    fn field_hook_contexts(&self) -> Vec<HookContext> {
+        vec![self.as_hook_context()]
     }
 }
 
@@ -122,8 +150,60 @@ impl<T: FieldSerializable> FieldSerializable for Option<T> {
     }
 }
 
+impl<T: FieldHookContexts> FieldHookContexts for Option<T> {
+    fn field_hook_contexts(&self) -> Vec<HookContext> {
+        match self {
+            Some(n) => n.field_hook_contexts(),
+            None => vec![],
+        }
+    }
+}
+
 impl<T: FieldSerializable> FieldSerializable for Vec<T> {
     fn field_as_serializable(&self) -> serde_json::Value {
         serde_json::Value::Array(self.iter().map(|n| n.field_as_serializable()).collect())
+    }
+}
+
+impl<T: FieldHookContexts> FieldHookContexts for Vec<T> {
+    fn field_hook_contexts(&self) -> Vec<HookContext> {
+        self.iter().flat_map(|n| n.field_hook_contexts()).collect()
+    }
+}
+
+impl_empty_field_hook_contexts!(
+    String,
+    bool,
+    Keyword,
+    SqliteStorageClass,
+    SchemaTableContainer
+);
+
+impl FieldHookContexts for PragmaInvocation {
+    fn field_hook_contexts(&self) -> Vec<HookContext> {
+        match self {
+            PragmaInvocation::Assign { value } | PragmaInvocation::Call { value } => {
+                value.field_hook_contexts()
+            }
+            PragmaInvocation::Query => vec![],
+        }
+    }
+}
+
+impl FieldHookContexts for ColumnConstraint {
+    fn field_hook_contexts(&self) -> Vec<HookContext> {
+        match self {
+            ColumnConstraint::Check(expr)
+            | ColumnConstraint::Default {
+                expr: Some(expr), ..
+            }
+            | ColumnConstraint::Generated { expr, .. }
+            | ColumnConstraint::As { expr, .. } => expr.field_hook_contexts(),
+            ColumnConstraint::Default {
+                literal: Some(literal),
+                ..
+            } => literal.field_hook_contexts(),
+            _ => vec![],
+        }
     }
 }

--- a/sqleibniz/src/parser/nodes.rs
+++ b/sqleibniz/src/parser/nodes.rs
@@ -1,5 +1,21 @@
-use crate::parser::debug::FieldSerializable;
-use crate::types::{Keyword, Token, storage::SqliteStorageClass};
+use crate::parser::debug::{FieldHookContexts, FieldSerializable};
+use crate::types::{Keyword, Token, ctx::HookContext, storage::SqliteStorageClass};
+
+macro_rules! field_hook_contexts {
+    () => {
+        Vec::new()
+    };
+    ($($field:expr),+ $(,)?) => {
+        vec![
+            $(
+                $field.field_hook_contexts(),
+            )+
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<HookContext>>()
+    };
+}
 
 macro_rules! node {
     ($node_name:ident,$documentation:literal,$($field_name:ident:$field_type:ty),*) => {
@@ -42,6 +58,20 @@ macro_rules! node {
                 serde_json::Value::Object(map)
             }
 
+            fn as_hook_context(&self) -> HookContext {
+                let children = field_hook_contexts!($(self.$field_name),*);
+
+                HookContext {
+                    node: stringify!($node_name).into(),
+                    kind: stringify!($node_name).into(),
+                    content: None,
+                    line: self.t.line,
+                    start: self.t.start,
+                    finish: self.t.end,
+                    children,
+                }
+            }
+
             fn doc(&self) -> &str {
                 $documentation
             }
@@ -63,6 +93,12 @@ macro_rules! node {
                 self.as_serializable()
             }
         }
+
+        impl FieldHookContexts for $node_name {
+            fn field_hook_contexts(&self) -> Vec<HookContext> {
+                vec![self.as_hook_context()]
+            }
+        }
     };
 }
 
@@ -73,6 +109,8 @@ pub trait Node: std::fmt::Debug {
     fn name(&self) -> &str;
     /// serializes self as json
     fn as_serializable(&self) -> serde_json::Value;
+    /// converts self into the data passed to Lua hooks
+    fn as_hook_context(&self) -> HookContext;
     /// returns the documentation url for sefl
     fn doc(&self) -> &str;
 

--- a/sqleibniz/src/types/ctx.rs
+++ b/sqleibniz/src/types/ctx.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use super::storage::SqliteStorageClass;
+use super::{Type, storage::SqliteStorageClass};
 
 pub struct Table {
     pub name: String,
@@ -16,18 +16,85 @@ pub struct Context {
 
 #[derive(Debug, Clone)]
 pub struct HookContext {
-    /// [Self::kind] will be the name of the node for most nodes, except nodes that hold different kinds, such as Literal, which can be an Ident, a String, a Number, etc.
+    pub node: String,
+    /// [Self::kind] holds the token kind for token-backed contexts and the node name otherwise.
     pub kind: String,
-    /// [Self::content] holds the textual representation of a nodes contents if it is [crates::parser::nodes::Literal].
+    /// [Self::content] holds the textual representation of token-backed contexts.
     pub content: Option<String>,
+    pub line: usize,
+    pub start: usize,
+    pub finish: usize,
     pub children: Vec<HookContext>,
+}
+
+impl HookContext {
+    pub fn node(node: impl Into<String>, line: usize, start: usize, finish: usize) -> Self {
+        let node = node.into();
+        Self {
+            kind: node.clone(),
+            node,
+            content: None,
+            line,
+            start,
+            finish,
+            children: vec![],
+        }
+    }
+
+    pub fn token(token: &super::Token) -> Self {
+        let (kind, content) = match &token.ttype {
+            Type::Keyword(keyword) => {
+                let keyword: &str = (*keyword).into();
+                ("Keyword", Some(keyword.to_string()))
+            }
+            Type::Ident(ident) => ("Ident", Some(ident.clone())),
+            Type::Number(number) => ("Number", Some(number.to_string())),
+            Type::String(string) => ("String", Some(string.clone())),
+            Type::Blob(bytes) => ("Blob", Some(format!("{bytes:x?}"))),
+            Type::Boolean(boolean) => ("Boolean", Some(boolean.to_string())),
+            Type::ParamName(name) => ("ParamName", Some(name.clone())),
+            Type::Param(param) => ("Param", Some(param.to_string())),
+            Type::Dot => ("Dot", Some(".".into())),
+            Type::Asterisk => ("Asterisk", Some("*".into())),
+            Type::Semicolon => ("Semicolon", Some(";".into())),
+            Type::Percent => ("Percent", Some("%".into())),
+            Type::Comma => ("Comma", Some(",".into())),
+            Type::Equal => ("Equal", Some("=".into())),
+            Type::Question => ("Question", Some("?".into())),
+            Type::Colon => ("Colon", Some(":".into())),
+            Type::At => ("At", Some("@".into())),
+            Type::Dollar => ("Dollar", Some("$".into())),
+            Type::BraceLeft => ("BraceLeft", Some("(".into())),
+            Type::BraceRight => ("BraceRight", Some(")".into())),
+            Type::BracketLeft => ("BracketLeft", Some("[".into())),
+            Type::BracketRight => ("BracketRight", Some("]".into())),
+            Type::InstructionExpect => ("InstructionExpect", None),
+            Type::Eof => ("Eof", None),
+        };
+
+        Self {
+            node: "Token".into(),
+            kind: kind.into(),
+            content,
+            line: token.line,
+            start: token.start,
+            finish: token.end,
+            children: vec![],
+        }
+    }
 }
 
 impl mlua::IntoLua for HookContext {
     fn into_lua(self, lua: &mlua::Lua) -> mlua::Result<mlua::Value> {
         let table = lua.create_table()?;
+        table.set("node", self.node)?;
         table.set("kind", self.kind)?;
-        table.set("text", self.content.unwrap_or_default())?;
+        let content = self.content.unwrap_or_default();
+        table.set("content", content.clone())?;
+        table.set("text", content)?;
+        table.set("line", self.line)?;
+        table.set("start", self.start)?;
+        table.set("finish", self.finish)?;
         table.set("children", self.children)?;
         lua.pack(table)
     }

--- a/sqleibniz/src/types/rules.rs
+++ b/sqleibniz/src/types/rules.rs
@@ -12,6 +12,8 @@ pub enum Rule {
     UnknownKeyword,
     /// Source file contains invalid sqleibniz instruction
     BadSqleibnizInstruction,
+    /// User-defined Lua hook reported a diagnostic
+    Hook,
     /// Source file uses sql features sqlite does not support
     SqliteUnsupported,
     /// Sqlite or SQL quirk: https://www.sqlite.org/quirks.html; anything where SQLite deviates
@@ -47,6 +49,7 @@ impl mlua::FromLua for Rule {
             "Syntax" => Self::Syntax,
             "Semicolon" => Self::Semicolon,
             "BadSqleibnizInstruction" => Self::BadSqleibnizInstruction,
+            "Hook" => Self::Hook,
             "UnknownKeyword" => Self::UnknownKeyword,
             "SqliteUnsupported" => Self::SqliteUnsupported,
             "Quirk" => Self::Quirk,
@@ -75,6 +78,7 @@ impl Rule {
             Self::Quirk => "Quirk",
             Self::Semicolon => "Semicolon",
             Self::BadSqleibnizInstruction => "BadSqleibnizInstruction",
+            Self::Hook => "Hook",
             Self::UnknownKeyword => "UnknownKeyword",
             Self::SqliteUnsupported => "SqliteUnsupported",
         }
@@ -96,6 +100,7 @@ impl Rule {
             Self::BadSqleibnizInstruction => {
                 "The source file contains an invalid sqleibniz instruction"
             }
+            Self::Hook => "User-defined Lua hook reported a diagnostic",
             Self::Quirk => "Sqlite or SQL quirk: https://www.sqlite.org/quirks.html",
             Self::UnknownKeyword => "Source file contains an unknown keyword",
             Self::SqliteUnsupported => "Source file uses sql features sqlite does not support",

--- a/sqleibniz/tests/hooks.rs
+++ b/sqleibniz/tests/hooks.rs
@@ -1,0 +1,113 @@
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+struct TempFile {
+    path: PathBuf,
+}
+
+impl TempFile {
+    fn new(name: &str, ext: &str, content: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "sqleibniz-{name}-{}-{}.{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            ext
+        ));
+        fs::write(&path, content).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn temp_file(name: &str, ext: &str, content: &str) -> TempFile {
+    TempFile::new(name, ext, content)
+}
+
+fn sqleibniz(args: &[&OsStr]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_sqleibniz"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn arg(value: &str) -> &OsStr {
+    OsStr::new(value)
+}
+
+fn file_arg(file: &TempFile) -> &OsStr {
+    file.path().as_os_str()
+}
+
+fn lowercase_hook_config() -> TempFile {
+    temp_file(
+        "hooks",
+        "lua",
+        r#"
+leibniz = {
+    hooks = {
+        {
+            name = "idents should be lowercase",
+            node = "Token",
+            hook = function(node)
+                if node.kind == "Ident" and string.match(node.content, "%u") then
+                    error("ident should be lowercase")
+                end
+            end
+        }
+    }
+}
+"#,
+    )
+}
+
+#[test]
+fn hook_error_reports_diagnostic() {
+    let config = lowercase_hook_config();
+    let sql = temp_file("uppercase-ident", "sql", "VACUUM UpperName;");
+
+    let output = sqleibniz(&[
+        arg("--kiss"),
+        arg("--config"),
+        file_arg(&config),
+        file_arg(&sql),
+    ]);
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Hook: idents should be lowercase"));
+    assert!(stdout.contains("ident should be lowercase"));
+}
+
+#[test]
+fn hook_diagnostics_can_be_disabled() {
+    let config = lowercase_hook_config();
+    let sql = temp_file("uppercase-ident-disabled", "sql", "VACUUM UpperName;");
+
+    let output = sqleibniz(&[
+        arg("--kiss"),
+        arg("--config"),
+        file_arg(&config),
+        arg("-D"),
+        arg("hook"),
+        file_arg(&sql),
+    ]);
+
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+}


### PR DESCRIPTION
- add Rule::Hook so user-defined Lua diagnostics can be filtered independently
- expose hook contexts for AST nodes and tokens
- execute configured Lua hooks during CLI analysis, mapping error(...) to Hook diagnostics
- update hook configuration docs and sample config

## Notes
- LSP still does not read leibniz.lua. Follow-up work should add LSP config loading and apply disabled rules there.
- Hook execution remains CLI-only for now; enabling Lua hooks in editor diagnostics should be decided separately because it has security and performance implications.