### PR TITLE
Allow LSP hooks behind explicit flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Options:
       --lsp
           invoke sqleibniz as a language server
 
+      --lsp-enable-hooks
+          execute configured Lua hooks in language server diagnostics
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -178,7 +181,8 @@ Consult [src/rules.rs](./src/rules.rs) for configuration documentation and
 [leibniz.lua](./leibniz.lua) for said example:
 
 The language server reads `disabled_rules` from the workspace `leibniz.lua`.
-Lua hooks are only executed by the CLI analysis path.
+Lua hooks are only executed in LSP diagnostics when `--lsp-enable-hooks` is
+passed explicitly.
 
 ````lua
 -- this is an example configuration, consult: https://www.lua.org/manual/5.4/
@@ -331,7 +335,8 @@ multiple lines.
 Sqleibniz has an LSP provider included, with in-editor diagnostics, hover info and other dx helpers.
 The language server loads `leibniz.lua` from the first workspace folder, then
 from the LSP `rootUri`, then from the current working directory. Only
-`disabled_rules` are applied in LSP mode; Lua hooks are ignored.
+`disabled_rules` are applied in LSP mode by default. Lua hooks are ignored
+unless the server is started with `--lsp-enable-hooks`.
 
 ### Setup in Neovim
 

--- a/sqleibniz/src/hooks.rs
+++ b/sqleibniz/src/hooks.rs
@@ -1,0 +1,61 @@
+use crate::{
+    error::Error,
+    parser::nodes::Node,
+    types::{Token, config::Hook, ctx::HookContext, rules::Rule},
+};
+
+fn hook_error_note(err: mlua::Error) -> String {
+    match err {
+        mlua::Error::RuntimeError(msg) => msg,
+        mlua::Error::CallbackError { cause, .. } => cause.to_string(),
+        err => err.to_string(),
+    }
+}
+
+fn hook_error(file: &str, hook: &Hook, ctx: &HookContext, err: mlua::Error) -> Error {
+    Error {
+        file: file.into(),
+        line: ctx.line,
+        rule: Rule::Hook,
+        note: hook_error_note(err),
+        msg: hook.name.clone(),
+        start: ctx.start,
+        end: ctx.finish,
+        improved_line: None,
+        doc_url: None,
+    }
+}
+
+fn hook_matches(hook: &Hook, ctx: &HookContext) -> bool {
+    hook.node
+        .as_deref()
+        .is_none_or(|node| node == ctx.node.as_str())
+}
+
+fn run_context(file: &str, hooks: &[Hook], ctx: &HookContext, errors: &mut Vec<Error>) {
+    for hook in hooks {
+        if hook_matches(hook, ctx) {
+            if let Err(err) = hook.exec(ctx.clone()) {
+                errors.push(hook_error(file, hook, ctx, err));
+            }
+        }
+    }
+
+    for child in &ctx.children {
+        run_context(file, hooks, child, errors);
+    }
+}
+
+pub fn run(file: &str, hooks: &[Hook], ast: &[Box<dyn Node>], tokens: &[Token]) -> Vec<Error> {
+    let mut errors = vec![];
+
+    for node in ast {
+        run_context(file, hooks, &node.as_hook_context(), &mut errors);
+    }
+
+    for token in tokens {
+        run_context(file, hooks, &HookContext::token(token), &mut errors);
+    }
+
+    errors
+}

--- a/sqleibniz/src/lib.rs
+++ b/sqleibniz/src/lib.rs
@@ -2,6 +2,8 @@
 pub mod error;
 /// highlight implements logic for highlighting tokens found in a string
 pub mod highlight;
+/// hooks executes user-defined lua hooks over AST and token contexts
+pub mod hooks;
 /// lev implements the levenshtein distance for all sql keywords, this is used to recommend a keyword based on a misspelled word or any
 /// unknown keyword at an arbitrary location in the source statement - mainly used at the start of a new statement
 pub mod lev;

--- a/sqleibniz/src/lsp/mod.rs
+++ b/sqleibniz/src/lsp/mod.rs
@@ -17,9 +17,13 @@ use lsp_types::{
 
 use crate::{
     error::Error,
+    hooks,
     lexer::Lexer,
     parser::{Parser, nodes::Node},
-    types::{config::Config, rules::Rule},
+    types::{
+        config::{Config, Hook},
+        rules::Rule,
+    },
 };
 
 macro_rules! lsp_log {
@@ -28,7 +32,7 @@ macro_rules! lsp_log {
     };
 }
 
-pub fn start() -> Result<(), LspError> {
+pub fn start(enable_hooks: bool) -> Result<(), LspError> {
     lsp_log!("starting language server");
     let (connection, threads) = Connection::stdio();
     let capabilities = serde_json::to_value(&ServerCapabilities {
@@ -68,7 +72,7 @@ pub fn start() -> Result<(), LspError> {
         }
     };
 
-    event_loop(connection, init_params)?;
+    event_loop(connection, init_params, enable_hooks)?;
 
     threads
         .join()
@@ -84,23 +88,35 @@ struct DocumentState {
     errors: Vec<super::error::Error>,
 }
 
-fn analyze_document(text: &[u8], name: &str) -> DocumentState {
+fn analyze_document(text: &[u8], name: &str, hooks: Option<&[Hook]>) -> DocumentState {
     let text = text.to_vec();
     let mut l = Lexer::new(&text, name);
     let tokens = l.run();
     let mut errors = l.errors;
-    let mut p = Parser::new(tokens, name);
+    let mut p = Parser::new(tokens.clone(), name);
     let ast = p.parse();
     errors.append(&mut p.errors);
+    if let Some(hooks) = hooks {
+        errors.append(&mut hooks::run(name, hooks, &ast, &tokens));
+    }
 
     DocumentState { ast, errors }
 }
 
-fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), LspError> {
+struct LspConfig {
+    config: Config,
+    _lua: Option<mlua::Lua>,
+}
+
+fn event_loop(
+    connection: Connection,
+    params: serde_json::Value,
+    enable_hooks: bool,
+) -> Result<(), LspError> {
     let params: InitializeParams = serde_json::from_value(params)
         .map_err(|err| format!("failed to parse initialize params: {err}"))?;
     lsp_log!("starting event loop");
-    let config = load_config(&params);
+    let config = load_config(&params, enable_hooks);
     let mut documents = HashMap::<String, DocumentState>::new();
     for msg in &connection.receiver {
         match msg {
@@ -141,7 +157,9 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 if let Err(e) = handlers::diagnostic::handle(
                                     &connection,
                                     state
-                                        .map(|s| filter_errors(&s.errors, &config.disabled_rules))
+                                        .map(|s| {
+                                            filter_errors(&s.errors, &config.config.disabled_rules)
+                                        })
                                         .unwrap_or_default(),
                                     id,
                                     params,
@@ -171,7 +189,11 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 let formatted_path = uri.replace("file://", "");
                                 documents.insert(
                                     uri,
-                                    analyze_document(change.text.as_bytes(), &formatted_path),
+                                    analyze_document(
+                                        change.text.as_bytes(),
+                                        &formatted_path,
+                                        config.config.hooks.as_deref(),
+                                    ),
                                 );
                             }
                         }
@@ -188,6 +210,7 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
                                 analyze_document(
                                     params.text_document.text.as_bytes(),
                                     &formatted_path,
+                                    config.config.hooks.as_deref(),
                                 ),
                             );
                         }
@@ -201,17 +224,29 @@ fn event_loop(connection: Connection, params: serde_json::Value) -> Result<(), L
     Ok(())
 }
 
-fn load_config(params: &InitializeParams) -> Config {
+fn load_config(params: &InitializeParams, enable_hooks: bool) -> LspConfig {
     let path = config_path(params);
     let lua = mlua::Lua::new();
-    match Config::rules_from_lua_file(&lua, &path.to_string_lossy()) {
+    let loaded_config = if enable_hooks {
+        Config::from_lua_file(&lua, &path.to_string_lossy())
+    } else {
+        Config::rules_from_lua_file(&lua, &path.to_string_lossy())
+    };
+
+    match loaded_config {
         Ok(config) => {
             eprintln!("[sqleibniz]: loaded config from {}", path.display());
-            config
+            LspConfig {
+                config,
+                _lua: enable_hooks.then_some(lua),
+            }
         }
         Err(err) => {
             eprintln!("[sqleibniz]: {err}");
-            Config::default()
+            LspConfig {
+                config: Config::default(),
+                _lua: None,
+            }
         }
     }
 }
@@ -298,6 +333,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{error::Error, lsp::filter_errors, types::rules::Rule};
+    use crate::{lsp::analyze_document, types::config::Hook};
 
     fn error(rule: Rule) -> Error {
         Error {
@@ -320,5 +356,43 @@ mod tests {
         let filtered = filter_errors(&errors, &[Rule::Hook]);
 
         assert_eq!(filtered, vec![error(Rule::Syntax)]);
+    }
+
+    #[test]
+    fn hooks_run_only_when_supplied_to_lsp_analysis() {
+        let lua = mlua::Lua::new();
+        let hook_fn = lua
+            .load(
+                r#"
+                return function(node)
+                    if node.kind == "Ident" and string.match(node.content, "%u") then
+                        error("ident should be lowercase")
+                    end
+                end
+            "#,
+            )
+            .eval()
+            .unwrap();
+        let hooks = vec![Hook {
+            name: "idents should be lowercase".into(),
+            node: Some("Token".into()),
+            hook: Some(hook_fn),
+        }];
+
+        let without_hooks = analyze_document(b"VACUUM UpperName;", "test.sql", None);
+        let with_hooks = analyze_document(b"VACUUM UpperName;", "test.sql", Some(&hooks));
+
+        assert!(
+            !without_hooks
+                .errors
+                .iter()
+                .any(|error| error.rule == Rule::Hook)
+        );
+        assert!(
+            with_hooks
+                .errors
+                .iter()
+                .any(|error| error.rule == Rule::Hook)
+        );
     }
 }

--- a/sqleibniz/src/main.rs
+++ b/sqleibniz/src/main.rs
@@ -9,10 +9,7 @@ use sqleibniz::error::{self, Error, print_str_colored, warn};
 use sqleibniz::highlight::builder;
 use sqleibniz::lexer::Lexer;
 use sqleibniz::parser;
-use sqleibniz::parser::nodes::Node;
-use sqleibniz::types::Token;
-use sqleibniz::types::config::{Config, Hook};
-use sqleibniz::types::ctx::HookContext;
+use sqleibniz::types::config::Config;
 use sqleibniz::types::rules::Rule;
 
 /// LSP and analysis cli for sql. Check for valid syntax, semantics and perform dynamic analysis.
@@ -58,6 +55,9 @@ struct Cli {
     /// invoke sqleibniz as a language server
     #[arg(long, conflicts_with = "sarif")]
     lsp: bool,
+    /// execute configured Lua hooks in language server diagnostics
+    #[arg(long, requires = "lsp")]
+    lsp_enable_hooks: bool,
     // TODO: add a --doc <fuzzy ast node / ast name> to print node documentation
 }
 
@@ -68,67 +68,11 @@ struct FileResult {
     diagnostics: Vec<Error>,
 }
 
-fn hook_error_note(err: mlua::Error) -> String {
-    match err {
-        mlua::Error::RuntimeError(msg) => msg,
-        mlua::Error::CallbackError { cause, .. } => cause.to_string(),
-        err => err.to_string(),
-    }
-}
-
-fn hook_error(file: &str, hook: &Hook, ctx: &HookContext, err: mlua::Error) -> Error {
-    Error {
-        file: file.into(),
-        line: ctx.line,
-        rule: Rule::Hook,
-        note: hook_error_note(err),
-        msg: hook.name.clone(),
-        start: ctx.start,
-        end: ctx.finish,
-        improved_line: None,
-        doc_url: None,
-    }
-}
-
-fn hook_matches(hook: &Hook, ctx: &HookContext) -> bool {
-    hook.node
-        .as_deref()
-        .is_none_or(|node| node == ctx.node.as_str())
-}
-
-fn run_hook_context(file: &str, hooks: &[Hook], ctx: &HookContext, errors: &mut Vec<Error>) {
-    for hook in hooks {
-        if hook_matches(hook, ctx) {
-            if let Err(err) = hook.exec(ctx.clone()) {
-                errors.push(hook_error(file, hook, ctx, err));
-            }
-        }
-    }
-
-    for child in &ctx.children {
-        run_hook_context(file, hooks, child, errors);
-    }
-}
-
-fn run_hooks(file: &str, hooks: &[Hook], ast: &[Box<dyn Node>], tokens: &[Token]) -> Vec<Error> {
-    let mut errors = vec![];
-
-    for node in ast {
-        run_hook_context(file, hooks, &node.as_hook_context(), &mut errors);
-    }
-
-    for token in tokens {
-        run_hook_context(file, hooks, &HookContext::token(token), &mut errors);
-    }
-
-    errors
-}
-
 fn main() {
     let args = Cli::parse();
 
     if args.lsp {
-        if let Err(e) = sqleibniz::lsp::start() {
+        if let Err(e) = sqleibniz::lsp::start(args.lsp_enable_hooks) {
             panic!("fatal error in language server: {}", e);
         }
         return;
@@ -253,7 +197,7 @@ fn main() {
             errors.append(&mut parser.errors);
 
             if let Some(hooks) = config.hooks.as_deref() {
-                errors.append(&mut run_hooks(&file.name, hooks, &ast, &toks));
+                errors.append(&mut sqleibniz::hooks::run(&file.name, hooks, &ast, &toks));
             }
         }
 


### PR DESCRIPTION
## Summary
- add --lsp-enable-hooks for opting into Lua hook diagnostics in LSP mode
- keep LSP hook execution disabled by default
- move hook execution into a shared library module used by CLI and LSP
- document the new flag and opt-in behavior

## Tests
- cargo test